### PR TITLE
Add another valid version

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
   extractId: function(url) {
     var match = urlRegex.exec(url);
     return match ? match[1] : false;
-  }
+  },
+  regex: urlRegex
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var urlRegex = /^(?:(?:https?:)?\/\/)?(?:www\.)?(?:youtu(?:be)?\.com\/(?:v\/|embed\/|watch\?.*?v=)|youtu\.be\/)((?:\w|-){11})(?:\S+)?$/;
+var urlRegex = /^(?:(?:https?:)?\/\/)?(?:www\.)?(?:youtu(?:be)?\.com\/(?:v\/|embed\/|watch(?:\/|\?v=))|youtu\.be\/)((?:\w|-){11})(?:\S+)?$/;
 
 module.exports = {
   valid: function(url) {

--- a/test.js
+++ b/test.js
@@ -4,6 +4,8 @@ var youtubeUrl = require('./index');
 var validUrls = [
   {url: 'https://www.youtube.com/watch?v=YoB8t0B4jx4', id: 'YoB8t0B4jx4'},
   {url: 'https://youtube.com/watch?v=YoB8t0B4jx4', id: 'YoB8t0B4jx4'},
+  {url: 'https://www.youtube.com/watch/YoB8t0B4jx4', id: 'YoB8t0B4jx4'},
+  {url: 'http://www.youtube.com/watch/YoB8t0B4jx4', id: 'YoB8t0B4jx4'},
   {url: 'http://www.youtube.com/watch?v=YoB8t0B4jx4', id: 'YoB8t0B4jx4'},
   {url: 'http://youtube.com/watch?v=YoB8t0B4jx4', id: 'YoB8t0B4jx4'},
   {url: 'www.youtube.com/watch?v=YoB8t0B4jx4', id: 'YoB8t0B4jx4'},


### PR DESCRIPTION
Review: @kesla @iefserge 
Type: Minor

As suggested by @kesla in https://github.com/micnews/embeds/pull/27. 
- Add support for `'https://www.youtube.com/watch/YoB8t0B4jx4` and `'http://www.youtube.com/watch/YoB8t0B4jx4` type urls. 
- Export regex